### PR TITLE
Fix details change to array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ export const queryDetails = function(results) {
     const analyzer = resultsObj.extensions && resultsObj.extensions.analyzer;
     const { resolvers } = analyzer.execution;
 
-    const details = resolvers.map(resolver => resolver.details);
+    const details = [].concat.apply([], resolvers.map(resolver => resolver.details));
 
     if (!analyzer) {
       return (


### PR DESCRIPTION
> this might break the plugin. The details key now returns an array.

This fixes the breaking changes introduced https://github.com/GraphQL-Query-Planner/graphql-analyzer/pull/8#issuecomment-372749281